### PR TITLE
add custom NullTime. upgrade go -> 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mikekonan/go-types
 
-go 1.14
+go 1.18
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1566,6 +1566,11 @@ components:
       example: 2006-01-02
       type: string
       x-go-type: github.com/mikekonan/go-types/time.Date
+    NullTime:
+      example: 2020-12-08T16:38:09.70516+03:00
+      type: string
+      nullable: true
+      x-go-type: github.com/mikekonan/go-types/time.Time
     Timezone:
       example: Europe/Minsk
       type: string

--- a/time/date.go
+++ b/time/date.go
@@ -1,7 +1,6 @@
 package time
 
 import (
-	"database/sql/driver"
 	"encoding/json"
 	"encoding/xml"
 	"gopkg.in/guregu/null.v4"
@@ -46,10 +45,6 @@ func (d *Date) UnmarshalXML(decoder *xml.Decoder, element xml.StartElement) erro
 
 func (d Date) MarshalXML(decoder *xml.Encoder, element xml.StartElement) error {
 	return decoder.EncodeElement(d.format(), element)
-}
-
-func (d Date) Value() (value driver.Value, err error) {
-	return null.Time(d).Value()
 }
 
 func (d Date) String() string {

--- a/time/date_test.go
+++ b/time/date_test.go
@@ -62,24 +62,18 @@ var unmarshalTestCases = []unmarshalType{
 }
 
 func TestUnmarshalJSON(t *testing.T) {
-	testUnmarshal(t,
-		func(bytes []byte, d *dt) error {
-			return json.Unmarshal(bytes, d)
-		}, func(u unmarshalType) []byte {
-			return u.testJSON
-		})
+	testUnmarshal(t, json.Unmarshal, func(u unmarshalType) []byte {
+		return u.testJSON
+	})
 }
 
 func TestUnmarshalXML(t *testing.T) {
-	testUnmarshal(t,
-		func(bytes []byte, d *dt) error {
-			return xml.Unmarshal(bytes, d)
-		}, func(u unmarshalType) []byte {
-			return u.testXML
-		})
+	testUnmarshal(t, xml.Unmarshal, func(u unmarshalType) []byte {
+		return u.testXML
+	})
 }
 
-func testUnmarshal(t *testing.T, unmarshalFunc func([]byte, *dt) error, valueFunc func(unmarshalType) []byte) {
+func testUnmarshal(t *testing.T, unmarshalFunc func([]byte, any) error, valueFunc func(unmarshalType) []byte) {
 	for _, testCase := range unmarshalTestCases {
 		var d dt
 		actualErr := unmarshalFunc(valueFunc(testCase), &d)
@@ -114,31 +108,25 @@ var marshalTestCases = []marshalType{
 }
 
 func TestMarshalJSON(t *testing.T) {
-	testMarshal(t, "json",
-		func(d dt) ([]byte, error) {
-			return json.Marshal(d)
-		}, func(m marshalType) []byte {
-			return m.expectedJSON
-		})
+	testMarshal(t, "json", json.Marshal, func(m marshalType) []byte {
+		return m.expectedJSON
+	})
 }
 
 func TestMarshalXML(t *testing.T) {
-	testMarshal(t, "xml",
-		func(d dt) ([]byte, error) {
-			return xml.Marshal(d)
-		}, func(m marshalType) []byte {
-			return m.expectedXML
-		})
+	testMarshal(t, "xml", xml.Marshal, func(m marshalType) []byte {
+		return m.expectedXML
+	})
 }
 
-func testMarshal(t *testing.T, tp string, marshalFunc func(dt) ([]byte, error), valueFunc func(marshalType) []byte) {
+func testMarshal(t *testing.T, tp string, marshalFunc func(any) ([]byte, error), valueFunc func(marshalType) []byte) {
 	for _, testCase := range marshalTestCases {
 		actual, actualErr := marshalFunc(testCase.testData)
 		if actualErr != nil {
 			t.Errorf(`%s`, actualErr)
 		}
 		if string(actual) != string(valueFunc(testCase)) {
-			t.Errorf("Actual %s does not equal expected. Actual: '%s', expected: '%s'", tp, actual, testCase.expectedXML)
+			t.Errorf("Actual %s does not equal expected. Actual: '%s', expected: '%s'", tp, actual, valueFunc(testCase))
 		}
 	}
 }

--- a/time/swagger.yaml
+++ b/time/swagger.yaml
@@ -5,3 +5,8 @@ components:
       example: 2006-01-02
       type: string
       x-go-type: github.com/mikekonan/go-types/time.Date
+    NullTime:
+      example: "2020-12-08T16:38:09.70516+03:00"
+      type: string
+      nullable: true
+      x-go-type: github.com/mikekonan/go-types/time.Time

--- a/time/time.go
+++ b/time/time.go
@@ -1,0 +1,77 @@
+package time
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"gopkg.in/guregu/null.v4"
+	"time"
+)
+
+type Time null.Time
+
+func NullTime(t time.Time) Time {
+	return Time(null.TimeFrom(t))
+}
+
+func (t *Time) UnmarshalJSON(data []byte) error {
+	var str string
+	err := json.Unmarshal(data, &str)
+	if err != nil {
+		return err
+	}
+
+	return t.parseTimeFromString(str)
+}
+
+func (t Time) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.format())
+}
+
+func (t *Time) UnmarshalXML(decoder *xml.Decoder, element xml.StartElement) error {
+	var str string
+	err := decoder.DecodeElement(&str, &element)
+	if err != nil {
+		return err
+	}
+
+	return t.parseTimeFromString(str)
+}
+
+func (t Time) MarshalXML(decoder *xml.Encoder, element xml.StartElement) error {
+	return decoder.EncodeElement(t.format(), element)
+}
+
+func (t Time) String() string {
+	var str = t.format()
+	if str != nil {
+		return *str
+	}
+	return ""
+}
+
+func (t Time) format() *string {
+	if t.Valid {
+		var str = t.Time.Format(time.RFC3339)
+		return &str
+	}
+
+	return nil
+}
+
+func (t *Time) parseTimeFromString(value string) (err error) {
+	if value == "" {
+		return nil
+	}
+
+	var newTime time.Time
+	if newTime, err = time.Parse(time.RFC3339, value); err != nil {
+		if errTime, ok := err.(*time.ParseError); ok {
+			return fmt.Errorf("cannot parse time '%s' invalid format '%s'", errTime.Value, errTime.Layout)
+		}
+		return err
+	}
+
+	*t = NullTime(newTime)
+	return nil
+}

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -1,0 +1,227 @@
+package time
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"testing"
+	"time"
+)
+
+type tm struct {
+	XMLName xml.Name `json:"-" xml:"test"`
+	T       Time     `json:"t,omitempty" xml:"t,omitempty"`
+}
+
+var unmarshalTimeTestCases = []unmarshalType{
+	{
+		testJSON:               []byte(`{}`),
+		testXML:                []byte(`<?xml version="1.0"?><test></test>`),
+		expectingValidateError: false,
+	},
+	{
+		testJSON:               []byte(`{"t": ""}`),
+		testXML:                []byte(`<?xml version="1.0"?><test><t></t></test>`),
+		expectingValidateError: false,
+	},
+	{
+		testJSON:               []byte(`{"t": "2022-05-10T12:35:10+03:00"}`),
+		testXML:                []byte(`<?xml version="1.0"?><test><t>2022-05-10T12:35:10+03:00</t></test>`),
+		expectingValidateError: false,
+	},
+	{
+		testJSON:               []byte(`{"t": 1234}`),
+		testXML:                []byte(`test><t>@</t>`),
+		expectingValidateError: true,
+	},
+	{
+		testJSON:               []byte(`{"t": "@"}`),
+		testXML:                []byte(`<?xml version="1.0"?><test><t>@</t></test>`),
+		expectingValidateError: true,
+	},
+	{
+		testJSON:               []byte(`{"t": "2006-01-02"}`),
+		testXML:                []byte(`<?xml version="1.0"?><test><t>2006-01-02</t></test>`),
+		expectingValidateError: true,
+	},
+	{
+		testJSON:               []byte(`{"t": "00:00:00"}`),
+		testXML:                []byte(`<?xml version="1.0"?><test><t>00:00:00</t></test>`),
+		expectingValidateError: true,
+	},
+	{
+		testJSON:               []byte(`{"t": "text-text-text"}`),
+		testXML:                []byte(`<?xml version="1.0"?><test><t>text-text-text</t></test>`),
+		expectingValidateError: true,
+	},
+}
+
+func TestTimeUnmarshalJSON(t *testing.T) {
+	testTimeUnmarshal(t, json.Unmarshal, func(u unmarshalType) []byte {
+		return u.testJSON
+	})
+}
+
+func TestTimeUnmarshalXML(t *testing.T) {
+	testTimeUnmarshal(t, xml.Unmarshal, func(u unmarshalType) []byte {
+		return u.testXML
+	})
+}
+
+func testTimeUnmarshal(t *testing.T, unmarshalFunc func([]byte, any) error, valueFunc func(unmarshalType) []byte) {
+	for _, testCase := range unmarshalTimeTestCases {
+		var d tm
+		actualErr := unmarshalFunc(valueFunc(testCase), &d)
+		if (actualErr == nil) == testCase.expectingValidateError {
+			t.Errorf(`Validate: '%s'. expecting error - '%v' but was opposite`, valueFunc(testCase), testCase.expectingValidateError)
+		}
+	}
+}
+
+type marshalTimeType struct {
+	testData     tm
+	expectedJSON []byte
+	expectedXML  []byte
+}
+
+var marshalTimeTestCases = []marshalTimeType{
+	{
+		testData:     tm{},
+		expectedJSON: []byte(`{"t":null}`),
+		expectedXML:  []byte(`<test></test>`),
+	},
+	{
+		testData:     tm{T: NullTime(time.Date(2006, 1, 2, 0, 0, 0, 0, time.UTC))},
+		expectedJSON: []byte(`{"t":"2006-01-02T00:00:00Z"}`),
+		expectedXML:  []byte(`<test><t>2006-01-02T00:00:00Z</t></test>`),
+	},
+	{
+		testData:     tm{T: NullTime(time.Date(1996, 8, 30, 10, 11, 40, 0, time.UTC))},
+		expectedJSON: []byte(`{"t":"1996-08-30T10:11:40Z"}`),
+		expectedXML:  []byte(`<test><t>1996-08-30T10:11:40Z</t></test>`),
+	},
+}
+
+func TestTimeMarshalJSON(t *testing.T) {
+	testTimeMarshal(t, "json", json.Marshal, func(m marshalTimeType) []byte {
+		return m.expectedJSON
+	})
+}
+
+func TestTimeMarshalXML(t *testing.T) {
+	testTimeMarshal(t, "xml", xml.Marshal, func(m marshalTimeType) []byte {
+		return m.expectedXML
+	})
+}
+
+func testTimeMarshal(t *testing.T, tp string, marshalFunc func(any) ([]byte, error), valueFunc func(timeType marshalTimeType) []byte) {
+	for _, testCase := range marshalTimeTestCases {
+		actual, actualErr := marshalFunc(testCase.testData)
+		if actualErr != nil {
+			t.Errorf(`%s`, actualErr)
+		}
+		if string(actual) != string(valueFunc(testCase)) {
+			t.Errorf("Actual %s does not equal expected. Actual: '%s', expected: '%s'", tp, actual, valueFunc(testCase))
+		}
+	}
+}
+
+func TestTimeFormatValid(t *testing.T) {
+	var (
+		d        = NullTime(time.Now())
+		expected = d.Time.Format(time.RFC3339)
+		str      = d.format()
+	)
+	if *str != expected {
+		t.Errorf("Invalid format(). Actual: %s, expected: %s", *str, expected)
+
+	}
+}
+
+func TestTimeFormatInvalid(t *testing.T) {
+	var (
+		d   = Time{}
+		str = d.format()
+	)
+	if str != nil {
+		t.Errorf("Invalid format(). Actual: %s, expected: nil", *str)
+
+	}
+}
+
+var testCaseTimeParseString = []struct {
+	value         string
+	expectedError bool
+}{
+	// not time
+	{
+		value:         "invalid-format",
+		expectedError: true,
+	},
+	// invalid format not rfc3339 w/a time
+	{
+		value:         "10-01-1996",
+		expectedError: true,
+	},
+	// date instead of date time
+	{
+		value:         "1996-09-29",
+		expectedError: true,
+	},
+	// only time instead of date time
+	{
+		value:         "00:00:00",
+		expectedError: true,
+	},
+	{
+		value:         "",
+		expectedError: false,
+	},
+	{
+		value:         "1998-02-20T12:21:40Z",
+		expectedError: false,
+	},
+}
+
+func TestParseTimeFromString(t *testing.T) {
+	for _, testCase := range testCaseTimeParseString {
+		var tm = &Time{}
+		actualErr := tm.parseTimeFromString(testCase.value)
+		if (actualErr == nil) == testCase.expectedError {
+			t.Errorf(`Expecting error - '%v' but was opposite`, testCase.expectedError)
+		}
+	}
+}
+
+var testCaseTimeString = []struct {
+	t              Time
+	expectedString string
+}{
+	{
+		t:              Time{},
+		expectedString: "",
+	},
+	{
+		t:              NullTime(time.Date(1996, 8, 30, 10, 11, 40, 0, time.UTC)),
+		expectedString: "1996-08-30T10:11:40Z",
+	},
+}
+
+func TestTimeString(t *testing.T) {
+	for _, testCase := range testCaseTimeString {
+		// empty var d = Date{}
+		var str = testCase.t.String()
+		if str != testCase.expectedString {
+			t.Errorf("Invalid String(). Actual: %s, expected: %s", str, testCase.expectedString)
+		}
+	}
+}
+
+func TestTimeValuer(t *testing.T) {
+	for _, testCase := range testCaseTimeString {
+		// empty var d = Date{}
+		var _, err = testCase.t.Value()
+		if err != nil {
+			t.Errorf("Invalid String(). Err: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Добавил нашу оберткну над null.Time для обработки кейса: 
```json
{
  "nullTime": ""
}
```
На стандартном null.Time падает такая ошибка: "error":"parsing time """" as ""2006-01-02T15:04:05Z07:00"": cannot parse """ as "2006""