### PR TITLE
unmarshal country codes to uppercase

### DIFF
--- a/country/alpha2.go
+++ b/country/alpha2.go
@@ -17,12 +17,14 @@ func (code *Alpha2Code) UnmarshalJSON(data []byte) error {
 
 	enumValue := Alpha2Code(str)
 	if len(enumValue) != 0 {
-		if _, err := ByAlpha2CodeErr(enumValue); err != nil {
+		country, err := ByAlpha2CodeErr(enumValue)
+		if err != nil {
 			return err
 		}
+
+		*code = country.Alpha2Code()
 	}
 
-	*code = enumValue
 	return nil
 }
 

--- a/country/alpha3.go
+++ b/country/alpha3.go
@@ -17,12 +17,14 @@ func (code *Alpha3Code) UnmarshalJSON(data []byte) error {
 
 	enumValue := Alpha3Code(str)
 	if len(enumValue) != 0 {
-		if _, err := ByAlpha3CodeErr(enumValue); err != nil {
+		country, err := ByAlpha3CodeErr(enumValue)
+		if err != nil {
 			return err
 		}
+
+		*code = country.Alpha3Code()
 	}
 
-	*code = enumValue
 	return nil
 }
 

--- a/country/country_test.go
+++ b/country/country_test.go
@@ -415,6 +415,11 @@ func TestAlpha2CodeUnmarshalJson(t *testing.T) {
 		t.FailNow()
 	}
 
+	var lowercase Alpha2CodeStruct
+	if err := json.Unmarshal([]byte(fmt.Sprintf(`{"code":"%s"}`, "ca")), &lowercase); err != nil || lowercase.Alpha2Code != Canada.Alpha2Code() {
+		t.FailNow()
+	}
+
 	var wrongCode Alpha2CodeStruct
 	if err := json.Unmarshal([]byte(fmt.Sprintf(`{"code":"%s"}`, "wrong code")), &wrongCode); err == nil {
 		t.FailNow()
@@ -438,6 +443,11 @@ func TestAlpha3CodeUnmarshalJson(t *testing.T) {
 
 	var negative Alpha3CodeStruct
 	if err := json.Unmarshal([]byte(fmt.Sprintf(`{"code":"%s"}`, "RUZ")), &negative); err == nil {
+		t.FailNow()
+	}
+
+	var lowercase Alpha3CodeStruct
+	if err := json.Unmarshal([]byte(fmt.Sprintf(`{"code":"%s"}`, "can")), &lowercase); err != nil || lowercase.Alpha3Code != Canada.Alpha3Code() {
 		t.FailNow()
 	}
 


### PR DESCRIPTION
When unmarshalling country codes into JSON, we first convert them to uppercase for validation. However, the resulting value is left in lowercase, which does not seem correct.