### PR TITLE
allow empty values when unmarshalling IP addresses

### DIFF
--- a/ip/ip.go
+++ b/ip/ip.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 )
 
+var ErrInvalidIPFormat = errors.New("ip address does not match either v4 or v6 IP format")
+
 type IP struct {
 	v4   IPv4
 	v6   IPv6
@@ -27,7 +29,7 @@ func (ip IP) Value() (value driver.Value, err error) {
 func (ip IP) Validate() error {
 	var fromStringIP, err = FromString(ip.String())
 	if err != nil {
-		return fmt.Errorf("'%s' is not an valid IP address, err: %w", ip, err)
+		return validationError(ip, "IP", err)
 	}
 
 	if fromStringIP.raw == ip.raw &&
@@ -42,22 +44,20 @@ func (ip IP) Validate() error {
 
 // UnmarshalJSON unmarshall implementation for IP
 func (ip *IP) UnmarshalJSON(data []byte) error {
-	var (
-		str string
-		err error
-	)
-	if err = json.Unmarshal(data, &str); err != nil {
+	if err := json.Unmarshal(data, &ip.raw); err != nil {
 		return err
 	}
 
-	var value IP
-	if value, err = FromString(str); err != nil && value.Validate() != nil {
-		return err
+	if err := json.Unmarshal(data, &ip.v4); err == nil {
+		return nil
 	}
 
-	*ip = value
+	if err := json.Unmarshal(data, &ip.v6); err == nil {
+		ip.isV6 = true
+		return nil
+	}
 
-	return nil
+	return ErrInvalidIPFormat
 }
 
 // MarshalJSON marshall implementation for IP
@@ -105,5 +105,9 @@ func FromString(value string) (IP, error) {
 		}, nil
 	}
 
-	return IP{}, errors.New("value isn't fit neither v4 nor v6 IP")
+	return IP{}, ErrInvalidIPFormat
+}
+
+func validationError(ip fmt.Stringer, ipType string, err error) error {
+	return fmt.Errorf("'%s' is not a valid %s address: %w", ip, ipType, err)
 }

--- a/ip/ip_v4.go
+++ b/ip/ip_v4.go
@@ -22,7 +22,7 @@ func (ip IPv4) Value() (value driver.Value, err error) {
 func (ip IPv4) Validate() error {
 	_, err := V4FromString(ip.String())
 	if err != nil {
-		return fmt.Errorf("'%s' is not an valid IPv4 address, err: %w", ip, err)
+		return validationError(ip, "IPv4", err)
 	}
 
 	return nil
@@ -35,12 +35,14 @@ func (ip *IPv4) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	value := IPv4(str)
-	if err := value.Validate(); err != nil {
-		return err
-	}
+	if str != "" {
+		value, err := V4FromString(str)
+		if err != nil {
+			return err
+		}
 
-	*ip = value
+		*ip = value
+	}
 
 	return nil
 }

--- a/ip/ip_v4_test.go
+++ b/ip/ip_v4_test.go
@@ -78,7 +78,7 @@ func TestIPv4_UnmarshalJSON(t *testing.T) {
 		{
 			name:    "empty",
 			ip:      "",
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/ip/ip_v6.go
+++ b/ip/ip_v6.go
@@ -22,7 +22,7 @@ func (ip IPv6) Value() (value driver.Value, err error) {
 func (ip IPv6) Validate() error {
 	_, err := V6FromString(ip.String())
 	if err != nil {
-		return fmt.Errorf("'%s' is not an valid IPv6 address, err: %w", ip, err)
+		return validationError(ip, "IPv6", err)
 	}
 
 	return nil
@@ -35,12 +35,14 @@ func (ip *IPv6) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	value := IPv6(str)
-	if err := value.Validate(); err != nil {
-		return err
-	}
+	if str != "" {
+		value, err := V6FromString(str)
+		if err != nil {
+			return err
+		}
 
-	*ip = value
+		*ip = value
+	}
 
 	return nil
 }

--- a/ip/ip_v6_test.go
+++ b/ip/ip_v6_test.go
@@ -3,6 +3,7 @@ package ip
 import (
 	"database/sql/driver"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -77,13 +78,13 @@ func TestIPv6_UnmarshalJSON(t *testing.T) {
 		{
 			name:    "empty",
 			ip:      "",
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var ipv6 IPv6
-			err := json.Unmarshal([]byte(tt.ip), &ipv6)
+			err := json.Unmarshal([]byte(fmt.Sprintf(`"%s"`, tt.ip)), &ipv6)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
- Enable unmarshallng of empty values into IP addresses without errors.
- Remove redundant validations during unmarshalling.
- Fix tests that were failing.